### PR TITLE
histo

### DIFF
--- a/src/Core/Bop.hs
+++ b/src/Core/Bop.hs
@@ -15,6 +15,7 @@
 module Core.Bop
     where
 
+import Data.Maybe
 import Data.Map qualified as M
 import Data.Set qualified as S
 
@@ -28,13 +29,14 @@ isBopString :: String -> Bool
 isBopString = all isAscSymbol 
 
 data Fixity
-    = InfixUnknown
-    | Infix
+    = Infix
     | InfixL
     | InfixR
     deriving (Eq, Show, Read)
 
-preludeOperators :: M.Map String (Int, Fixity)
+type BopInfo = (Int, Fixity)
+
+preludeOperators :: M.Map String BopInfo
 preludeOperators = M.fromList 
     [ ("!!", (9, InfixL))
     , ("." , (9, InfixR))
@@ -68,19 +70,27 @@ preludeOperators = M.fromList
     , ("`seq`", (0, InfixL))
     ]
 
+operators :: M.Map String BopInfo
+operators = M.unions [preludeOperators]
+
 isBop :: String -> Bool
 isBop op = M.member op 
-         $ M.unions [preludeOperators]
+         $ operators
+
+bopInfoOf :: String -> BopInfo
+bopInfoOf op
+    = fromMaybe (error $ "bopInfoOf: unknown operator" ++ op)
+    $ operators M.!? op
 
 precedenceOf :: String -> Int
 precedenceOf op 
     = maybe (error $ "precedenceOf: unknown operator " ++ show op) fst 
-    $ preludeOperators M.!? op
+    $ operators M.!? op
 
 fixityOf :: String -> Fixity
 fixityOf op
     = maybe (error $ "fixityOf: unknown operator" ++ show op) snd 
-    $ preludeOperators M.!? op
+    $ operators M.!? op
 
 {- ^
 >>> isBop "++"

--- a/src/Core/Language.hs
+++ b/src/Core/Language.hs
@@ -98,6 +98,9 @@ apoExpr = apo
 hyloExpr :: (ExprF a c -> c) -> (b -> ExprF a b) -> b -> c
 hyloExpr = hylo
 
+histoExpr :: (ExprF a (AnnExpr a b) -> b) -> Expr a -> b
+histoExpr = histo
+
 {- AnnProgram -}
 
 type AnnProgram a ann = [AnnScDefn a ann]
@@ -150,3 +153,18 @@ deAnnExpr = cataAnnExpr phi where
         _ F.:< ELetF bs e    -> ELet bs e
         _ F.:< ECaseF e alts -> ECase e alts
         _ F.:< ELamF xs e    -> ELam xs e
+
+class VarRep a where
+    vname :: a -> Name
+
+instance VarRep Name where
+    vname :: Name -> Name
+    vname = id
+
+instance VarRep (a, Name) where
+    vname :: (a, Name) -> Name
+    vname = snd
+
+instance VarRep (Name, a) where
+    vname :: (Name, a) -> Name
+    vname = fst

--- a/src/Core/Pretty.hs
+++ b/src/Core/Pretty.hs
@@ -15,10 +15,14 @@
 module Core.Pretty
     where
 
+import Control.Arrow hiding ((<+>))
 import Control.Comonad.Cofree
 import Control.Comonad.Trans.Cofree qualified as F
 import Data.Functor.Foldable
 
+import Data.Char
+import Data.Bool
+import Data.List ( dropWhileEnd, isPrefixOf )
 import Data.Maybe
 import Data.Text qualified as T
 import Prettyprinter
@@ -27,38 +31,159 @@ import Prettyprinter.Util
 import Core.Language
 import Core.Bop
 
-pprExpr :: (a -> Doc ann) -> Expr a -> Doc ann
-pprExpr ppr = paraExpr phi where
+pprExpr :: forall a. VarRep a 
+        => forall ann. (a -> Doc ann) -> Expr a -> Doc ann
+pprExpr ppr = snd . histoExpr phi where
     phi = \ case
-        EVarF v      -> pretty v
-        ENumF n      -> pretty n
-        EConstrF t a -> "Pack" <> braces (surround comma (pretty t) (pretty a))
-        EApF e1 e2   -> pap1 e1 <+> pap2 e2
-        ELetF bs body
-            -> "let" <> hardline 
-            <> indent 4 (align (vsep (punctuate semi (map (\ (a,r) -> group (ppr a <+> "=" <+> snd r)) bs)))) <> hardline
-            <> indent -4 "in" <> hardline
-            <> indent 4 (snd body)
-        ECaseF e alts 
-            -> "case" <+> (snd e) <+> "of" <> hardline
-            <> indent 4 (vsep (punctuate semi (map (palt ppr) alts)))
-        ELamF xs e -> group ("λ" <+> hsep (map ppr xs) <+> "→") <+> snd e
+        EVarF v      -> (maxBound, pretty v)
+        ENumF n      -> (maxBound, pretty n)
+        EConstrF t a -> (maxBound, "Pack" <> braces (surround comma (pretty t) (pretty a)))
+        EApF e1 e2 -> case e1 of
+            (_,_) :< EApF e11 e12 -> case e11 of
+                (_,d11) :< EVarF bop
+                    | isBop bop -> case bopInfoOf bop of
+                        (p,Infix)   -> case e12 of
+                            (o1,do1) :< _ -> case e2 of
+                                (o2,do2) :< _
+                                    -> (p, doc) where
+                                        doc = parens' (p >= o1) do1
+                                            <+> d11
+                                            <+> parens' (p >= o2) do2
+                        (p,InfixL)  -> case e12 of
+                            (o1,do1) :< _ -> case e2 of
+                                (o2,do2) :< _
+                                    -> (p, doc) where
+                                        doc = parens' (p > o1) do1
+                                            <+> d11
+                                            <+> parens' (p >= o2) do2
+                        (p,InfixR)  -> case e12 of
+                            (o1,do1) :< _ -> case e2 of
+                                (o2,do2) :< _
+                                    -> (p, doc) where
+                                        doc = parens' (p >= o1) do1
+                                            <+> d11
+                                            <+> parens' (p > o2) do2
+                    | otherwise -> pprEAp e1 e2
+                _ -> pprEAp e1 e2
+            _ -> pprEAp e1 e2
+        ELetF bs e   -> (minBound, doc) where
+            doc = "let" <> hardline 
+                <> indent 4 bs' <> hardline
+                <> indent -4 "in" <> hardline
+                <> indent 4 e'
+            bs' = pprBinders bs
+            e'  = case e of
+                (_,d) :< _ -> d
+        ECaseF e alts -> (minBound, doc) where
+            doc = "case" <+> e' <+> "of" <> hardline
+               <> indent 4 alts'
+            e' = case e of
+                (_,d) :< _ -> d
+            alts' = pprAlts alts
+        ELamF xs body -> case sectionTypeOf xs body of
+            NotSection           -> pprELam xs body
+            SectionBoth bop      -> (maxBound, bop') where
+                bop' = pprBop bop
+            SectionL bop info (p,d1) -> case info of                 -- (x +)
+                (o,Infix)  -> (maxBound, parens doc) where
+                    doc = parens' (o >= p) d1 <+> pretty bop
+                (o,InfixL) -> (maxBound, parens doc) where
+                    doc = parens' (o >= p) d1 <+> pretty bop
+                (o,InfixR) -> (maxBound, parens doc) where
+                    doc = parens' (o >  p) d1 <+> pretty bop
+            SectionR bop info (q,d2) -> case info of                 -- (+ y)
+                (o,Infix)  -> (maxBound, parens doc) where
+                    doc = pretty bop <+> parens' (o >= q) d2
+                (o,InfixL) -> (maxBound, parens doc) where
+                    doc = pretty bop <+> parens' (o >  q) d2
+                (o,InfixR) -> (maxBound, parens doc) where
+                    doc = pretty bop <+> parens' (o >= q) d2
 
-pap1 :: (Expr a, Doc ann) -> Doc ann
-pap1 (e,d) = case e of
-    ELet _ _  -> parens d
-    ECase _ _ -> parens d
-    ELam _ _  -> parens d
-    _         -> d
+    pprEAp e1 e2 =  case (snd *** snd) (pprFun e1, pprArg e2) of
+        (d1,d2) -> (10 :: Int, d1 <+> d2)
 
-pap2 :: (Expr a, Doc ann) -> Doc ann
-pap2 (e,d) = case e of
-    EVar _ -> d
-    ENum _ -> d
-    _      -> parens d
+    pprFun = \ case
+        (p,doc) :< _ -> (bool maxBound p (p == 10), parens' (p < 10) doc)
 
-palt :: (a -> Doc ann) -> (Int, [a], (Expr a, Doc ann)) -> Doc ann
-palt ppr (t,xs,(_,d)) = angles (pretty t) <+> hsep (ppr <$> xs) <+> "→" <+> d
+    pprArg = \ case
+        (p,doc) :< _ -> (undefined, parens' (p < maxBound) doc)
+
+    pprBinders
+        = align
+        . vsep
+        . punctuate semi
+        . map (\ (a,(_,d):<_) -> group (ppr a <+> "=" <+> d))
+
+    pprAlts
+        = align
+        . vsep
+        . punctuate semi
+        . map (\ (t,xs,(_,d) :< _) -> angles (pretty t)
+                                <+> hsep (ppr <$> xs)
+                                <+> "→" <+> d)
+    
+    pprELam xs body = (minBound, doc) where
+        doc = case body of
+            (_,body') :< _ -> group ("λ" <+> hsep (map ppr xs) <+> "→") <+> body'
+
+data SectionType d
+    = NotSection
+    | SectionBoth Name    -- (+)
+    | SectionL Name BopInfo d  -- (x +)
+    | SectionR Name BopInfo d  -- (+ y)
+
+sectionTypeOf :: VarRep a => [a] -> AnnExpr a (Int, Doc ann) -> SectionType (Int, Doc ann)
+sectionTypeOf xs body = case xs of
+    [x] -> case body of
+        _ :< EApF e1 e2 -> case e1 of
+            _ :< EApF e11 e12 -> case e11 of
+                _ :< EVarF bop
+                    | isBop bop -> case e12 of
+                        ae12 :< EVarF y -> case e2 of
+                            ae2 :< EVarF z
+                                | y == z       -> NotSection
+                                | vname x == y -> SectionR bop (bopInfoOf bop) ae2
+                                | vname x == z -> SectionL bop (bopInfoOf bop) ae12
+                                | otherwise    -> NotSection
+                            ae2 :< _ 
+                                | vname x == y -> SectionR bop (bopInfoOf bop) ae2
+                                | otherwise    -> NotSection
+                        ae12 :< _       -> case e2 of
+                            _ :< EVarF z
+                                | vname x == z -> SectionL bop (bopInfoOf bop) ae12
+                                | otherwise    -> NotSection
+                            _                  -> NotSection
+                _               -> NotSection
+            _                 -> NotSection
+        _               -> NotSection
+    [x,y] -> case body of
+        _ :< EApF e1 e2 -> case e2 of
+            _ :< EVarF w
+                | vname y /= w  -> NotSection
+                | otherwise     -> case e1 of
+                    _ :< EApF e11 e12 -> case e11 of
+                        _ :< EVarF bop
+                            | isBop bop   -> case e12 of
+                                _ :< EVarF z  
+                                    | vname x == z -> SectionBoth bop
+                                _                  -> NotSection
+                        _                 -> NotSection
+                    _                 -> NotSection
+            _               -> NotSection
+        _               -> NotSection
+    _   -> NotSection
+
+parens' :: Bool -> Doc ann -> Doc ann
+parens' = \ case
+    False -> id
+    _     -> parens
+
+pprBop :: String -> Doc ann
+pprBop = \ case
+    bop | "`" `isPrefixOf` bop -> pretty (trim bop)
+        | otherwise            -> parens (pretty bop)
+    where
+        trim = dropWhileEnd ('`' ==) . dropWhile ('`' ==)
 
 pprCore :: Name -> Doc ann
 pprCore = pretty
@@ -66,15 +191,16 @@ pprCore = pretty
 pprCoreExpr :: CoreExpr -> Doc ann
 pprCoreExpr = pprExpr pprCore
 
-
-
 {- |
->>> vsep $ pprCoreExpr . sample <$> [1 .. 8]
+>>> vsep $ pprCoreExpr . sample <$> [1 .. 18]
 x
 7
 Pack{2,2}
 f (g x)
 f g x
+2 + 3
+(2 + 3) * 5
+(2 + 3) * 5 - 7
 let
     x = 1;
     xs = Pack{1,0}
@@ -86,21 +212,37 @@ case f (g x) of
 λ f g x → case f (g x) of
     <1>  → 0;
     <2> h hs → succ (length hs)
-
+(+ y)
+(x +)
+(+)
+mod
+λ x z → x + y
+λ z y → x + y
+λ z w → x + y
 -}
 sample :: Int -> CoreExpr
 sample i = fromMaybe (ENum 404) (lookup i sampleExprs)
 
 sampleExprs :: [(Int, CoreExpr)]
 sampleExprs
-    = 
-    [(1, EVar "x")
-    ,(2, ENum 7)
-    ,(3, EConstr 2 2)
-    ,(4, EAp (EVar "f") (EAp (EVar "g") (EVar "x")))
-    ,(5, EAp (EAp (EVar "f") (EVar "g")) (EVar "x"))
-    ,(6, ELet [("x",ENum 1),("xs", EConstr 1 0)] (EAp (EAp (EConstr 2 2) (EVar "x")) (EVar "xs")))
-    ,(7, ECase (sample 4) [(1,[],ENum 0),(2,["h","hs"],EAp (EVar "succ") (EAp (EVar "length") (EVar "hs")))])
-    ,(8, ELam ["f","g","x"] (sample 7))
+    = zip [1 ..]
+    [ EVar "x"
+    , ENum 7
+    , EConstr 2 2
+    , EAp (EVar "f") (EAp (EVar "g") (EVar "x"))
+    , EAp (EAp (EVar "f") (EVar "g")) (EVar "x")
+    , EAp (EAp (EVar "+") (ENum 2)) (ENum 3)       -- 2 + 3
+    , EAp (EAp (EVar "*") (sample 6)) (ENum 5)     -- (2 + 3) * 5
+    , EAp (EAp (EVar "-") (sample 7)) (ENum 7)     -- (2 + 3) * 5 - 7
+    , ELet [("x",ENum 1),("xs", EConstr 1 0)] (EAp (EAp (EConstr 2 2) (EVar "x")) (EVar "xs"))
+    , ECase (sample 4) [(1,[],ENum 0),(2,["h","hs"],EAp (EVar "succ") (EAp (EVar "length") (EVar "hs")))]
+    , ELam ["f","g","x"] (sample 10)
+    , ELam ["x"] (EAp (EAp (EVar "+") (EVar "x")) (EVar "y"))
+    , ELam ["y"] (EAp (EAp (EVar "+") (EVar "x")) (EVar "y"))
+    , ELam ["x","y"] (EAp (EAp (EVar "+") (EVar "x")) (EVar "y"))
+    , ELam ["x","y"] (EAp (EAp (EVar "`mod`") (EVar "x")) (EVar "y"))
+    , ELam ["x","z"] (EAp (EAp (EVar "+") (EVar "x")) (EVar "y"))
+    , ELam ["z","y"] (EAp (EAp (EVar "+") (EVar "x")) (EVar "y"))
+    , ELam ["z","w"] (EAp (EAp (EVar "+") (EVar "x")) (EVar "y"))
     ]
 


### PR DESCRIPTION
closes #3

- **二項演算子情報の変更**
- **VarRepクラス追加**
- **プリティプリンタをhistoで再構成**

中置二項演算子を扱うためには、
1. 対象が EAp e1 e2 であること
2. e1 が EAp e11 e12 であること
3. e11 が EVar bop であること
4. bop が二項演算子であること
を判定する必要がある。

paramorphism では 1. しか判定できない。
histomorphism を使って、Exprと同じ構造に計算結果を格納することで 2.と 3. の判定を行えるようにする。

